### PR TITLE
Update default image tag to 0.2

### DIFF
--- a/helm/postfix/values.yaml
+++ b/helm/postfix/values.yaml
@@ -34,7 +34,7 @@ serviceAccount:
 # Docker image
 image:
   repository: eldada-docker-examples.bintray.io/postfix-relay
-  tag: 0.1
+  tag: 0.2
   pullPolicy: IfNotPresent
 
 # Expose pods with service on port 25


### PR DESCRIPTION
This was previously set to older release 0.1, which meant the TX_SMTP_RELAY_NETWORKS setting had no affect.